### PR TITLE
some fixes

### DIFF
--- a/mongolog/handlers.py
+++ b/mongolog/handlers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 *-*
+import sys
 import getpass
 import logging
 
@@ -12,6 +13,8 @@ try:
 except ImportError:
     from pymongo import Connection
 
+if sys.version_info[0] >= 3:
+    unicode = str
 
 class MongoFormatter(logging.Formatter):
     def format(self, record):


### PR DESCRIPTION
- don't overwrite record.msg as the record may be passed to other handlers too
- Python 3 doesn't have`unicode()`
