### PR TITLE
Drop support for old Python versions and update PyMongo methods usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.swp
 *.nja
+.eggs/*
+mongolog.egg-info/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+    dist: xenial
+    sudo: true
   - "pypy"
 services: mongodb
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ python:
   - "pypy"
 services: mongodb
 install:
-  - "pip install -r requirements.txt --use-mirrors"
+  - "pip install -r requirements.txt"
 script: "python test.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-    dist: xenial
-    sudo: true
-  - "pypy"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
+    - pypy
 services: mongodb
 install:
   - "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-    - "pypy"
+    - pypy
 services: mongodb
 install:
   - "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
   - "pypy"
 services: mongodb
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: python
-matrix:
-  include:
-    - python: 2.7
-    - python: 3.4
-    - python: 3.5
-    - python: 3.6
-    - python: 3.7
-      dist: xenial
-      sudo: true
-    - pypy
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+    dist: xenial
+    sudo: true
+  - "pypy"
 services: mongodb
 install:
   - "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-    - pypy
+    - "pypy"
 services: mongodb
 install:
   - "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
-    dist: xenial
-    sudo: true
   - "pypy"
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 services: mongodb
 install:
   - "pip install -r requirements.txt"

--- a/mongolog/handlers.py
+++ b/mongolog/handlers.py
@@ -70,7 +70,7 @@ class MongoHandler(logging.Handler):
     def emit(self, record):
         """ Store the record to the collection. Async insert """
         try:
-            self.collection.insert(self.format(record))
+            self.collection.insert_one(self.format(record))
         except InvalidDocument as e:
             logging.error("Unable to save log record: %s", e.message,
                 exc_info=True)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     packages=['mongolog'],
     keywords=["mongolog", "logging", "mongo", "mongodb"],
     install_requires=['pymongo'],
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
     classifiers=[
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     install_requires=['pymongo'],
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
     classifiers=[
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Topic :: System :: Logging",
-        "Topic :: Database"],
+        "Topic :: Database",
+    ]
 )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,10 +24,11 @@ class TestAuth(unittest.TestCase):
         self.collection = self.db[self.collection_name]
 
         self.conn.drop_database(self.db_name)
-        self.db.command({
-            'createUser': self.user_name,
-            'pwd': self.password,
-        })
+        self.db.command(
+            'createUser',
+            self.user_name,
+            {'pwd': self.password}
+        )
 
     def tearDown(self):
         """ Drop used database """

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,7 @@ class TestAuth(unittest.TestCase):
         self.db.command(
             'createUser',
             self.user_name,
-            {'pwd': self.password}
+            pwd=self.password
         )
 
     def tearDown(self):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,7 +24,7 @@ class TestAuth(unittest.TestCase):
         self.collection = self.db[self.collection_name]
 
         self.conn.drop_database(self.db_name)
-        self.db.add_user(self.user_name, self.password)
+        self.db.createUser(self.user_name, self.password)
 
     def tearDown(self):
         """ Drop used database """

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,8 @@ class TestAuth(unittest.TestCase):
         self.db.command(
             'createUser',
             self.user_name,
-            pwd=self.password
+            pwd=self.password,
+            roles=["readWrite"]
         )
 
     def tearDown(self):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,7 +24,10 @@ class TestAuth(unittest.TestCase):
         self.collection = self.db[self.collection_name]
 
         self.conn.drop_database(self.db_name)
-        self.db.createUser(self.user_name, self.password)
+        self.db.command({
+            'createUser': self.user_name,
+            'pwd': self.password,
+        })
 
     def tearDown(self):
         """ Drop used database """

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -74,7 +74,7 @@ class TestRootLoggerHandler(unittest.TestCase):
             docs_count,
             1,
             "Expected query to return 1 "
-            "message; it returned %d" % docs_count()
+            "message; it returned %d" % docs_count
         )
         self.assertEqual(cursor[0]['msg']['address'], '340 N 12th St')
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -65,19 +65,26 @@ class TestRootLoggerHandler(unittest.TestCase):
         log.info({'address': '340 S 12th St', 'state': 'PA', 'country': 'US'})
         log.info({'address': '1234 Market St', 'state': 'PA', 'country': 'US'})
 
-        cursor = self.collection.find({'levelname': 'INFO',
-            'msg.address': '340 N 12th St'})
+        query = {
+            'levelname': 'INFO',
+            'msg.address': '340 N 12th St'},
+        )
+        docs_count = self.collection.count_documents(query)
         self.assertEqual(
-            cursor.count_documents(),
+            docs_count,
             1,
             "Expected query to return 1 "
-            "message; it returned %d" % cursor.count_documents()
+            "message; it returned %d" % docs_count()
         )
         self.assertEqual(cursor[0]['msg']['address'], '340 N 12th St')
 
-        cursor = self.collection.find({'levelname': 'INFO',
-            'msg.state': 'PA'})
-
+        query = {
+            'levelname': 'INFO',
+            'msg.state': 'PA',
+        }
+        docs_count = self.collection.count_documents(query)
         self.assertEqual(
-            cursor.count_documents(), 3, "Didn't find all three documents"
+            docs_count,
+            3,
+            "Didn't find all three documents"
         )

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -67,11 +67,17 @@ class TestRootLoggerHandler(unittest.TestCase):
 
         cursor = self.collection.find({'levelname': 'INFO',
             'msg.address': '340 N 12th St'})
-        self.assertEqual(cursor.count(), 1, "Expected query to return 1 "
-            "message; it returned %d" % cursor.count())
+        self.assertEqual(
+            cursor.count_documents(),
+            1,
+            "Expected query to return 1 "
+            "message; it returned %d" % cursor.count_documents()
+        )
         self.assertEqual(cursor[0]['msg']['address'], '340 N 12th St')
 
         cursor = self.collection.find({'levelname': 'INFO',
             'msg.state': 'PA'})
 
-        self.assertEqual(cursor.count(), 3, "Didn't find all three documents")
+        self.assertEqual(
+            cursor.count_documents(), 3, "Didn't find all three documents"
+        )

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -67,8 +67,8 @@ class TestRootLoggerHandler(unittest.TestCase):
 
         query = {
             'levelname': 'INFO',
-            'msg.address': '340 N 12th St'},
-        )
+            'msg.address': '340 N 12th St',
+        }
         docs_count = self.collection.count_documents(query)
         self.assertEqual(
             docs_count,

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -76,6 +76,7 @@ class TestRootLoggerHandler(unittest.TestCase):
             "Expected query to return 1 "
             "message; it returned %d" % docs_count
         )
+        cursor = self.collection.find(query)
         self.assertEqual(cursor[0]['msg']['address'], '340 N 12th St')
 
         query = {


### PR DESCRIPTION
PyMongo has removed support for various Python versions and it's not worthwhile to keep doing it here.
Also, this changeset prevents to use of deprecated methods from PyMongo since they are going to be removed in a soon-to-be-released version.

As an additional note, this changeset removes unneeded pip argument named ``--use-mirrors`` and adds Python 3.7 configuration needed for Travis CI.